### PR TITLE
use go after installation without rebooting PC

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -28,6 +28,7 @@ $ mkdir $HOME/go
 $ nano ~/.bashrc
 export GOPATH=$HOME/go
 export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+$ source ~/.bashrc
 $ go version
 ```
 


### PR DESCRIPTION
added command to reload .bashrc after adding go to $PATH.
Now users can use go after installation without rebooting their workstation.